### PR TITLE
Practice

### DIFF
--- a/audrey.js
+++ b/audrey.js
@@ -1,28 +1,19 @@
 const audrey = document.getElementById("audrey")
 
-/*
-    [x] Add an event listener to the `document` object to listen
-    for the "scroll" event.
-*/
-
 const adjustAudrey = (event) => {
-    audrey.style.width = `${window.scrollY / 3}px`;
-    audrey.style.height = `${window.scrollY / 4}px`;
+    if (window.scrollY / 3 > 50){
+        audrey.style.width = `${window.scrollY / 3}px`;
+    } else {
+        audrey.style.widows = "50px";
+    }
+    if (window.scrollY / 4 > 100) {
+        audrey.style.height = `${window.scrollY / 4}px`;
+    } else {
+        audrey.style.height = "100px";
+    }
+    
 } 
 
 document.addEventListener("scroll", adjustAudrey)
-    /*
-        [x] Adjust the width of audrey to be 1/3 the value of
-        `window.scrollY`. 
-        [ ] No lower than 50px, though.
-    */
-
-
-
-    /*
-        [x] Adjust the height of audrey to be 1/4 the value of
-        `window.scrollY`. 
-        [ ] No lower than 100px, though.
-    */
 
     

--- a/audrey.js
+++ b/audrey.js
@@ -1,19 +1,28 @@
 const audrey = document.getElementById("audrey")
 
 /*
-    Add an event listener to the `document` object to listen
+    [x] Add an event listener to the `document` object to listen
     for the "scroll" event.
 */
-.addEventListener("", function () {
+
+const adjustAudrey = (event) => {
+    audrey.style.width = `${window.scrollY / 3}px`;
+    audrey.style.height = `${window.scrollY / 4}px`;
+} 
+
+document.addEventListener("scroll", adjustAudrey)
     /*
-        Adjust the width of audrey to be 1/3 the value of
-        `window.scrollY`. No lower than 50px, though.
+        [x] Adjust the width of audrey to be 1/3 the value of
+        `window.scrollY`. 
+        [ ] No lower than 50px, though.
     */
 
 
 
     /*
-        Adjust the height of audrey to be 1/4 the value of
-        `window.scrollY`. No lower than 100px, though.
+        [x] Adjust the height of audrey to be 1/4 the value of
+        `window.scrollY`. 
+        [ ] No lower than 100px, though.
     */
-})
+
+    


### PR DESCRIPTION
Confirm the following behavior is working:    

- [x] Add an event listener to the `document` object to listen for the "scroll" event.

- [x] Adjust the width of audrey to be 1/3 the value of `window.scrollY`. No lower than 50px, though.

- [x] Adjust the height of audrey to be 1/4 the value of `window.scrollY`. No lower than 100px, though.
